### PR TITLE
Increasing the contrast of admonition by choosing #d6d6d6 as background

### DIFF
--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -186,7 +186,7 @@
 
 .doc .admonitionblock td.content {
   padding: 1rem 1rem 0.75rem;
-  background-color: #aaa;
+  background-color: #d6d6d6;
   width: 100%;
 }
 


### PR DESCRIPTION
This will change the background of admonition from #aaa to #d6d6d6, this ensures a greater contrast with the content of the admonition block.