### PR TITLE
Remove GA and HubSpot integrations

### DIFF
--- a/src/partials/head-scripts.hbs
+++ b/src/partials/head-scripts.hbs
@@ -1,10 +1,4 @@
-    {{#with site.keys.googleAnalytics}}
-    <script async src="https://www.googletagmanager.com/gtag/js?id={{this}}"></script>
-    <script>function gtag(){dataLayer.push(arguments)};window.dataLayer=window.dataLayer||[];gtag('js',new Date());gtag('config','{{this}}')</script>
-    {{/with}}
     <script>var uiRootPath = '{{{uiRootPath}}}'</script>
     {{#with site.keys.searchPagePath}}
     <script>var searchPagePath = '{{this}}'</script>
     {{/with}}
-    {{!-- HubSpot --}}
-    <script type="text/javascript" id="hs-script-loader" async defer src="//js.hs-scripts.com/7105834.js"></script>


### PR DESCRIPTION
Using these integrations is controversial and many users and browsers
started to actively block them (like Enhanced Tracking Protection in
Firefox).